### PR TITLE
bug: Emby bug fix 403

### DIFF
--- a/ansible/includes/emby.yml
+++ b/ansible/includes/emby.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   connection: local
   vars:
-    emby_version: "4.6.4.0"
+    emby_version: "4.7.0.11"
     emby_download_url: "https://github.com/MediaBrowser/Emby.Releases/releases/download/{{ emby_version }}/emby-server-deb_{{ emby_version }}_amd64.deb"
     emby_root: "/var/lib/emby"
 


### PR DESCRIPTION
Changing Emby version.
Last stable released version is giving a 403