### PR TITLE
bug: Downgrade to 4.6.3.0

### DIFF
--- a/ansible/includes/emby.yml
+++ b/ansible/includes/emby.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   connection: local
   vars:
-    emby_version: "4.7.0.11"
+    emby_version: "4.6.3.0"
     emby_download_url: "https://github.com/MediaBrowser/Emby.Releases/releases/download/{{ emby_version }}/emby-server-deb_{{ emby_version }}_amd64.deb"
     emby_root: "/var/lib/emby"
 


### PR DESCRIPTION
Downgrading since 4.6.4.0 [link](https://github.com/MediaBrowser/Emby.Releases/releases/download/4.6.4.0/emby-server-deb_4.6.4.0_amd64.deb) no longer works.
And 4.7.0.11 gives [error](https://github.com/MediaBrowser/emby-webcomponents/issues/12)