### PR TITLE
needed `do-udp` to make aws domain resolution work

### DIFF
--- a/ansible/includes/pihole.yml
+++ b/ansible/includes/pihole.yml
@@ -39,6 +39,21 @@
           - 127.0.0.1@5353
         unbound_forward_zone_configuration:
           - forward-tls-upstream: "yes"
+        unbound_configuration:
+          - verbosity: 1
+          - do-ip4: "yes"
+          - do-ip6: "no"
+          - do-udp: "yes"
+          - do-tcp: "yes"
+          - num-threads: 1
+          - pidfile: "/var/run/unbound.pid"
+          - logfile: "{{unbound_logfile}}"
+          - log-time-ascii: "yes"
+          - log-queries: "yes"
+          - log-replies: "yes"
+          - log-tag-queryreply: "yes"
+          - log-local-actions: "yes"
+          - log-servfail: "yes"
       when: not ansible_check_mode
 
     - name: create pihole required folders


### PR DESCRIPTION
otherwise fails silently.

```
Apr 14 10:20:04 unbound[2658568:0] query: 127.0.0.1 somedomain.us-west-2.es.amazonaws.com. A IN
Apr 14 10:20:04 unbound[2658568:0] info: resolving somedomain.us-west-2.es.amazonaws.com. A IN
Apr 14 10:20:04 unbound[2658568:0] info: response for somedomain.us-west-2.es.amazonaws.com. A IN
Apr 14 10:20:04 unbound[2658568:0] info: reply from <.> 8.8.8.8#853
Apr 14 10:20:04 unbound[2658568:0] info: query response was nodata ANSWER
Apr 14 10:20:04 unbound[2658568:0] info: resolving amazonaws.com. DS IN
Apr 14 10:20:04 unbound[2658568:0] info: NSEC3s for the referral proved no DS.
Apr 14 10:20:04 unbound[2658568:0] info: Verified that unsigned response is INSECURE
Apr 14 10:20:04 unbound[2658568:0] reply: 127.0.0.1 somedomain.us-west-2.es.amazonaws.com. A IN NOERROR 0.109960 0 107
```
