### PR TITLE
Jellyfin vaapi performance

### DIFF
--- a/ansible/files/jellyfin/default/Movies/options.xml
+++ b/ansible/files/jellyfin/default/Movies/options.xml
@@ -14,7 +14,7 @@
   <EnableAutomaticSeriesGrouping>false</EnableAutomaticSeriesGrouping>
   <EnableEmbeddedTitles>false</EnableEmbeddedTitles>
   <EnableEmbeddedEpisodeInfos>false</EnableEmbeddedEpisodeInfos>
-  <AutomaticRefreshIntervalDays>0</AutomaticRefreshIntervalDays>
+  <AutomaticRefreshIntervalDays>1</AutomaticRefreshIntervalDays>
   <PreferredMetadataLanguage />
   <MetadataCountryCode />
   <SeasonZeroDisplayName>Specials</SeasonZeroDisplayName>

--- a/ansible/files/jellyfin/default/Movies/options.xml
+++ b/ansible/files/jellyfin/default/Movies/options.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LibraryOptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <EnablePhotos>true</EnablePhotos>
-  <EnableRealtimeMonitor>true</EnableRealtimeMonitor>
+  <EnablePhotos>false</EnablePhotos>
+  <EnableRealtimeMonitor>false</EnableRealtimeMonitor>
   <EnableChapterImageExtraction>false</EnableChapterImageExtraction>
   <ExtractChapterImagesDuringLibraryScan>false</ExtractChapterImagesDuringLibraryScan>
   <PathInfos>

--- a/ansible/files/jellyfin/default/Shows/options.xml
+++ b/ansible/files/jellyfin/default/Shows/options.xml
@@ -14,7 +14,7 @@
   <EnableAutomaticSeriesGrouping>false</EnableAutomaticSeriesGrouping>
   <EnableEmbeddedTitles>false</EnableEmbeddedTitles>
   <EnableEmbeddedEpisodeInfos>false</EnableEmbeddedEpisodeInfos>
-  <AutomaticRefreshIntervalDays>0</AutomaticRefreshIntervalDays>
+  <AutomaticRefreshIntervalDays>1</AutomaticRefreshIntervalDays>
   <PreferredMetadataLanguage />
   <MetadataCountryCode />
   <SeasonZeroDisplayName>Specials</SeasonZeroDisplayName>

--- a/ansible/files/jellyfin/default/Shows/options.xml
+++ b/ansible/files/jellyfin/default/Shows/options.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LibraryOptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <EnablePhotos>true</EnablePhotos>
-  <EnableRealtimeMonitor>true</EnableRealtimeMonitor>
+  <EnablePhotos>false</EnablePhotos>
+  <EnableRealtimeMonitor>false</EnableRealtimeMonitor>
   <EnableChapterImageExtraction>false</EnableChapterImageExtraction>
   <ExtractChapterImagesDuringLibraryScan>false</ExtractChapterImagesDuringLibraryScan>
   <PathInfos>

--- a/ansible/files/jellyfin/encoding.xml
+++ b/ansible/files/jellyfin/encoding.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <EncodingOptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <EncodingThreadCount>0</EncodingThreadCount>
+  <EncodingThreadCount>2</EncodingThreadCount>
   <TranscodingTempPath>/var/lib/jellyfin/transcodes</TranscodingTempPath>
   <FallbackFontPath />
   <EnableFallbackFont>false</EnableFallbackFont>
   <DownMixAudioBoost>2</DownMixAudioBoost>
   <MaxMuxingQueueSize>2048</MaxMuxingQueueSize>
-  <EnableThrottling>false</EnableThrottling>
+  <EnableThrottling>true</EnableThrottling>
   <ThrottleDelaySeconds>180</ThrottleDelaySeconds>
-  <HardwareAccelerationType />
+  <HardwareAccelerationType>vaapi</HardwareAccelerationType>
   <EncoderAppPath>/usr/lib/jellyfin-ffmpeg/ffmpeg</EncoderAppPath>
   <EncoderAppPathDisplay>/usr/lib/jellyfin-ffmpeg/ffmpeg</EncoderAppPathDisplay>
   <VaapiDevice>/dev/dri/renderD128</VaapiDevice>
@@ -26,14 +26,15 @@
   <EncoderPreset />
   <DeinterlaceDoubleRate>false</DeinterlaceDoubleRate>
   <DeinterlaceMethod>yadif</DeinterlaceMethod>
-  <EnableDecodingColorDepth10Hevc>true</EnableDecodingColorDepth10Hevc>
-  <EnableDecodingColorDepth10Vp9>true</EnableDecodingColorDepth10Vp9>
-  <EnableEnhancedNvdecDecoder>true</EnableEnhancedNvdecDecoder>
+  <EnableDecodingColorDepth10Hevc>false</EnableDecodingColorDepth10Hevc>
+  <EnableDecodingColorDepth10Vp9>false</EnableDecodingColorDepth10Vp9>
+  <EnableEnhancedNvdecDecoder>false</EnableEnhancedNvdecDecoder>
   <EnableHardwareEncoding>true</EnableHardwareEncoding>
-  <AllowHevcEncoding>true</AllowHevcEncoding>
+  <AllowHevcEncoding>false</AllowHevcEncoding>
   <EnableSubtitleExtraction>true</EnableSubtitleExtraction>
   <HardwareDecodingCodecs>
     <string>h264</string>
+    <string>mpeg2video</string>
     <string>vc1</string>
   </HardwareDecodingCodecs>
 </EncodingOptions>

--- a/ansible/files/jellyfin/system.xml
+++ b/ansible/files/jellyfin/system.xml
@@ -160,11 +160,16 @@
   <UICulture>en-US</UICulture>
   <SaveMetadataHidden>false</SaveMetadataHidden>
   <ContentTypes />
-  <RemoteClientBitrateLimit>0</RemoteClientBitrateLimit>
+  <RemoteClientBitrateLimit>12000000</RemoteClientBitrateLimit>
   <EnableFolderView>false</EnableFolderView>
   <EnableGroupingIntoCollections>false</EnableGroupingIntoCollections>
   <DisplaySpecialsWithinSeasons>true</DisplaySpecialsWithinSeasons>
-  <LocalNetworkSubnets />
+  <LocalNetworkSubnets>
+    <string>10.0.0.0/8</string>
+    <string>172.16.0.0/12</string>
+    <string>192.168.0.0/16</string>
+    <string>127.0.0.0/8</string>
+  </LocalNetworkSubnets>
   <LocalNetworkAddresses />
   <CodecsUsed />
   <PluginRepositories>
@@ -187,7 +192,9 @@
   <CorsHosts>
     <string>*</string>
   </CorsHosts>
-  <KnownProxies />
+  <KnownProxies>
+    <string>172.16.0.1</string>
+  </KnownProxies>
   <ActivityLogRetentionDays>30</ActivityLogRetentionDays>
   <LibraryScanFanoutConcurrency>0</LibraryScanFanoutConcurrency>
   <LibraryMetadataRefreshConcurrency>0</LibraryMetadataRefreshConcurrency>

--- a/ansible/includes/jellyfin.yml
+++ b/ansible/includes/jellyfin.yml
@@ -62,6 +62,27 @@
         name: jellyfin
         selection: hold
 
+    - name: Install VA-API drivers for Intel hardware transcoding
+      apt:
+        name:
+          - i965-va-driver
+          - mesa-va-drivers
+        state: present
+
+    - name: Check prime-select profile
+      command: prime-select query
+      register: prime_profile
+      changed_when: false
+      failed_when: false
+      when: not ansible_check_mode
+
+    - name: Use Intel GPU for VA-API on Optimus laptops
+      command: prime-select intel
+      when:
+        - not ansible_check_mode
+        - prime_profile.stdout is defined
+        - prime_profile.stdout != "intel"
+
     - name: Ensure Jellyfin server is enabled
       systemd:
         name: "jellyfin"


### PR DESCRIPTION
## Summary
- Enable Intel VAAPI hardware transcoding for Optimus laptops (HD 4000 / Dell E6530-class hardware), including VA-API driver install and `prime-select intel`
- Tune transcoding for a low-core CPU: 2 encode threads, throttling enabled, remote bitrate cap at 12 Mbps, HEVC/NVENC options disabled
- Improve reverse-proxy behavior via Traefik KnownProxies and LAN subnet trust for better direct play
- Reduce NFS library overhead: disable realtime monitoring and photo scanning; schedule daily metadata refresh instead

## Test plan
- [ ] Merge and run ansible-pull on `next` (requires Optimus enabled in BIOS and Intel GPU visible in `lspci`)
- [ ] Confirm `sudo -u jellyfin vainfo --display drm --device /dev/dri/renderD128` succeeds
- [ ] Play a transcode-required stream and verify ffmpeg uses `h264_vaapi` in `journalctl -u jellyfin`
- [ ] Confirm LAN clients direct-play H.264 content without unnecessary video transcode
- [ ] Verify daily library refresh runs (Dashboard → Scheduled Tasks)