### PR TITLE
Move Jellyfin proxy and LAN settings to network.xml for 10.11.

### DIFF
--- a/ansible/files/jellyfin/network.xml
+++ b/ansible/files/jellyfin/network.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<NetworkConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <BaseUrl />
+  <EnableHttps>false</EnableHttps>
+  <RequireHttps>false</RequireHttps>
+  <CertificatePath />
+  <CertificatePassword />
+  <InternalHttpPort>8096</InternalHttpPort>
+  <InternalHttpsPort>8920</InternalHttpsPort>
+  <PublicHttpPort>8096</PublicHttpPort>
+  <PublicHttpsPort>8920</PublicHttpsPort>
+  <AutoDiscovery>true</AutoDiscovery>
+  <EnableUPnP>false</EnableUPnP>
+  <EnableIPv4>true</EnableIPv4>
+  <EnableIPv6>false</EnableIPv6>
+  <EnableRemoteAccess>true</EnableRemoteAccess>
+  <LocalNetworkSubnets>
+    <string>10.0.0.0/8</string>
+    <string>172.16.0.0/12</string>
+    <string>192.168.0.0/16</string>
+    <string>127.0.0.0/8</string>
+  </LocalNetworkSubnets>
+  <LocalNetworkAddresses />
+  <KnownProxies>
+    <string>172.17.0.4</string>
+  </KnownProxies>
+  <IgnoreVirtualInterfaces>true</IgnoreVirtualInterfaces>
+  <VirtualInterfaceNames>
+    <string>veth</string>
+  </VirtualInterfaceNames>
+  <EnablePublishedServerUriByRequest>false</EnablePublishedServerUriByRequest>
+  <PublishedServerUriBySubnet />
+  <RemoteIPFilter />
+  <IsRemoteIPFilterBlacklist>false</IsRemoteIPFilterBlacklist>
+</NetworkConfiguration>

--- a/ansible/files/jellyfin/system.xml
+++ b/ansible/files/jellyfin/system.xml
@@ -2,39 +2,13 @@
 <ServerConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <LogFileRetentionDays>3</LogFileRetentionDays>
   <IsStartupWizardCompleted>true</IsStartupWizardCompleted>
-  <EnableUPnP>false</EnableUPnP>
   <EnableMetrics>true</EnableMetrics>
-  <PublicPort>8096</PublicPort>
-  <UPnPCreateHttpPortMap>false</UPnPCreateHttpPortMap>
-  <UDPPortRange />
-  <EnableIPV6>false</EnableIPV6>
-  <EnableIPV4>true</EnableIPV4>
-  <EnableSSDPTracing>false</EnableSSDPTracing>
-  <SSDPTracingFilter />
-  <UDPSendCount>2</UDPSendCount>
-  <UDPSendDelay>100</UDPSendDelay>
-  <IgnoreVirtualInterfaces>true</IgnoreVirtualInterfaces>
-  <VirtualInterfaceNames>vEthernet*</VirtualInterfaceNames>
-  <GatewayMonitorPeriod>60</GatewayMonitorPeriod>
-  <TrustAllIP6Interfaces>false</TrustAllIP6Interfaces>
-  <HDHomerunPortRange />
-  <PublishedServerUriBySubnet />
-  <AutoDiscoveryTracing>false</AutoDiscoveryTracing>
-  <AutoDiscovery>true</AutoDiscovery>
-  <PublicHttpsPort>8920</PublicHttpsPort>
-  <HttpServerPortNumber>8096</HttpServerPortNumber>
-  <HttpsPortNumber>8920</HttpsPortNumber>
-  <EnableHttps>false</EnableHttps>
   <EnableNormalizedItemByNameIds>true</EnableNormalizedItemByNameIds>
-  <CertificatePath />
-  <CertificatePassword />
   <IsPortAuthorized>true</IsPortAuthorized>
   <QuickConnectAvailable>false</QuickConnectAvailable>
-  <EnableRemoteAccess>true</EnableRemoteAccess>
   <EnableCaseSensitiveItemIds>true</EnableCaseSensitiveItemIds>
   <DisableLiveTvChannelUserDataName>true</DisableLiveTvChannelUserDataName>
   <MetadataPath />
-  <MetadataNetworkPath />
   <PreferredMetadataLanguage>en</PreferredMetadataLanguage>
   <MetadataCountryCode>US</MetadataCountryCode>
   <SortReplaceCharacters>
@@ -60,8 +34,10 @@
   <MinResumeDurationSeconds>300</MinResumeDurationSeconds>
   <MinAudiobookResume>5</MinAudiobookResume>
   <MaxAudiobookResume>5</MaxAudiobookResume>
+  <InactiveSessionThreshold>0</InactiveSessionThreshold>
   <LibraryMonitorDelay>60</LibraryMonitorDelay>
-  <EnableDashboardResponseCaching>true</EnableDashboardResponseCaching>
+  <LibraryUpdateDuration>30</LibraryUpdateDuration>
+  <CacheSize>400</CacheSize>
   <ImageSavingConvention>Legacy</ImageSavingConvention>
   <MetadataOptions>
     <MetadataOptions>
@@ -156,21 +132,14 @@
   </MetadataOptions>
   <SkipDeserializationForBasicTypes>true</SkipDeserializationForBasicTypes>
   <ServerName />
-  <BaseUrl />
   <UICulture>en-US</UICulture>
   <SaveMetadataHidden>false</SaveMetadataHidden>
   <ContentTypes />
   <RemoteClientBitrateLimit>12000000</RemoteClientBitrateLimit>
   <EnableFolderView>false</EnableFolderView>
-  <EnableGroupingIntoCollections>false</EnableGroupingIntoCollections>
+  <EnableGroupingMoviesIntoCollections>false</EnableGroupingMoviesIntoCollections>
+  <EnableGroupingShowsIntoCollections>false</EnableGroupingShowsIntoCollections>
   <DisplaySpecialsWithinSeasons>true</DisplaySpecialsWithinSeasons>
-  <LocalNetworkSubnets>
-    <string>10.0.0.0/8</string>
-    <string>172.16.0.0/12</string>
-    <string>192.168.0.0/16</string>
-    <string>127.0.0.0/8</string>
-  </LocalNetworkSubnets>
-  <LocalNetworkAddresses />
   <CodecsUsed />
   <PluginRepositories>
     <RepositoryInfo>
@@ -180,23 +149,36 @@
     </RepositoryInfo>
   </PluginRepositories>
   <EnableExternalContentInSuggestions>true</EnableExternalContentInSuggestions>
-  <RequireHttps>false</RequireHttps>
-  <EnableNewOmdbSupport>true</EnableNewOmdbSupport>
-  <RemoteIPFilter />
-  <IsRemoteIPFilterBlacklist>false</IsRemoteIPFilterBlacklist>
   <ImageExtractionTimeoutMs>0</ImageExtractionTimeoutMs>
   <PathSubstitutions />
-  <UninstalledPlugins />
   <EnableSlowResponseWarning>true</EnableSlowResponseWarning>
   <SlowResponseThresholdMs>500</SlowResponseThresholdMs>
   <CorsHosts>
     <string>*</string>
   </CorsHosts>
-  <KnownProxies>
-    <string>172.16.0.1</string>
-  </KnownProxies>
   <ActivityLogRetentionDays>30</ActivityLogRetentionDays>
   <LibraryScanFanoutConcurrency>0</LibraryScanFanoutConcurrency>
   <LibraryMetadataRefreshConcurrency>0</LibraryMetadataRefreshConcurrency>
-  <RemoveOldPlugins>false</RemoveOldPlugins>
+  <AllowClientLogUpload>true</AllowClientLogUpload>
+  <DummyChapterDuration>0</DummyChapterDuration>
+  <ChapterImageResolution>MatchSource</ChapterImageResolution>
+  <ParallelImageEncodingLimit>0</ParallelImageEncodingLimit>
+  <CastReceiverApplications />
+  <TrickplayOptions>
+    <EnableHwAcceleration>false</EnableHwAcceleration>
+    <EnableHwEncoding>false</EnableHwEncoding>
+    <EnableKeyFrameOnlyExtraction>false</EnableKeyFrameOnlyExtraction>
+    <ScanBehavior>NonBlocking</ScanBehavior>
+    <ProcessPriority>BelowNormal</ProcessPriority>
+    <Interval>10000</Interval>
+    <WidthResolutions>
+      <int>320</int>
+    </WidthResolutions>
+    <TileWidth>10</TileWidth>
+    <TileHeight>10</TileHeight>
+    <Qscale>4</Qscale>
+    <JpegQuality>90</JpegQuality>
+    <ProcessThreads>1</ProcessThreads>
+  </TrickplayOptions>
+  <EnableLegacyAuthorization>true</EnableLegacyAuthorization>
 </ServerConfiguration>

--- a/ansible/includes/jellyfin.yml
+++ b/ansible/includes/jellyfin.yml
@@ -9,6 +9,7 @@
     jellyfin_system_config_files:
       - system.xml
       - encoding.xml
+      - network.xml
 
   tasks:
     - name: Add an Apt signing key for Jellyfin


### PR DESCRIPTION
KnownProxies now points at Caddy on app_network (172.17.0.4) so Jellyfin trusts X-Forwarded-For and sees real client IPs behind the reverse proxy.