### PR TITLE
Pin Matter Server to eno1 as primary interface

### DIFF
--- a/ansible/includes/homeassistant.yml
+++ b/ansible/includes/homeassistant.yml
@@ -41,14 +41,23 @@
         state: started
         pull: false
         network_mode: "host"
+        command:
+          - "--storage-path"
+          - "/data"
+          - "--paa-root-cert-dir"
+          - "/data/credentials"
+          - "--primary-interface"
+          - "eno1"
         container_default_behavior: "compatibility"
+        comparisons:
+          command: strict
         volumes:
           - '/opt/matter-server:/data'
       register: matter_result
       retries: 5
       delay: 3
       until: matter_result is succeeded
-      when: - not ansible_check_mode
+      when: not ansible_check_mode
 
     - name: Deploy homeassistant bootstrap config
       template:


### PR DESCRIPTION
## Summary
- Pass `--primary-interface eno1` to the Matter Server container so link-local addressing uses the LAN NIC.
- Fix invalid `when:` syntax on the Matter deploy task.

## Test plan
- [ ] Confirm ansible-pull recreates `matter-server` with `--primary-interface eno1`
- [ ] Check `docker logs matter-server` reports `Using 'eno1' as primary interface`
- [ ] Verify Matter Server still initializes successfully


Made with [Cursor](https://cursor.com)