### PR TITLE
Expose local APC USB UPS to Home Assistant via NUT

### DIFF
--- a/ansible/includes/homeassistant.yml
+++ b/ansible/includes/homeassistant.yml
@@ -48,7 +48,7 @@
       retries: 5
       delay: 3
       until: matter_result is succeeded
-      when: - not ansible_check_mode
+      when: not ansible_check_mode
 
     - name: Deploy homeassistant bootstrap config
       template:
@@ -88,15 +88,14 @@
           - '/opt/homeassistant:/config'
           - '/etc/localtime:/etc/localtime:ro'
           - '/run/dbus:/run/dbus:ro'
-        devices:
-          - '/dev/ttyUSB0:/dev/ttyUSB0'
+        # APC UPS is owned by host NUT (nut.yml). HA uses the NUT integration
+        # against 127.0.0.1:3493 via host networking — no USB device map needed.
       # added retry to tasks dependant on external services
       register: result
       retries: 5
       delay: 3
       until: result is succeeded
-      when:
-        - not ansible_check_mode
+      when: not ansible_check_mode
 
     - name: Run backup of homeassistant at 1am within first 15 minutes
       block:

--- a/ansible/includes/nut.yml
+++ b/ansible/includes/nut.yml
@@ -1,0 +1,87 @@
+---
+
+- name: "Network UPS Tools (APC USB)"
+  hosts: localhost
+  connection: local
+  handlers:
+    - name: Restart nut
+      shell: |
+        upsdrvctl stop || true
+        systemctl restart nut-server
+        upsdrvctl start
+        systemctl restart nut-monitor
+      args:
+        executable: /bin/bash
+      when: not ansible_check_mode
+  tasks:
+    - name: Install NUT packages
+      package:
+        name:
+          - nut
+          - nut-client
+          - nut-server
+        state: present
+
+    - name: Generate NUT password
+      set_fact:
+        nut_password: "{{ lookup('password', '/root/nut_password length=24 chars=ascii_letters,digits') }}"
+
+    - name: Deploy NUT configuration
+      template:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        owner: root
+        group: nut
+        mode: "0640"
+      loop:
+        - { src: "../templates/nut/nut.conf.j2", dest: "/etc/nut/nut.conf" }
+        - { src: "../templates/nut/ups.conf.j2", dest: "/etc/nut/ups.conf" }
+        - { src: "../templates/nut/upsd.conf.j2", dest: "/etc/nut/upsd.conf" }
+        - { src: "../templates/nut/upsd.users.j2", dest: "/etc/nut/upsd.users" }
+        - { src: "../templates/nut/upsmon.conf.j2", dest: "/etc/nut/upsmon.conf" }
+      notify: Restart nut
+
+    - name: Enable and start NUT services
+      systemd:
+        name: "{{ item }}"
+        enabled: true
+        state: started
+      loop:
+        - nut-server
+        - nut-monitor
+      when: not ansible_check_mode
+
+    - name: Ensure UPS drivers are running
+      command: upsdrvctl start
+      register: upsdrvctl_start
+      changed_when: false
+      failed_when: false
+      when: not ansible_check_mode
+
+    - name: Verify APC UPS is readable via NUT
+      command: upsc apc@localhost
+      register: upsc_apc
+      changed_when: false
+      retries: 5
+      delay: 3
+      until: upsc_apc.rc == 0
+      when: not ansible_check_mode
+
+    - name: Show APC UPS status summary
+      debug:
+        msg: "{{ upsc_apc.stdout_lines | select('match', '^(battery.charge|ups.status|ups.model|device.serial):') | list }}"
+      when:
+        - not ansible_check_mode
+        - upsc_apc is succeeded
+
+    - name: Write Home Assistant NUT connection hints
+      copy:
+        dest: /root/nut_ha_connection.txt
+        mode: "0600"
+        content: |
+          Home Assistant NUT integration settings (host networking):
+            Host: 127.0.0.1
+            Port: 3493
+            Username: homeassistant
+            Password: {{ nut_password }}
+            UPS: apc

--- a/ansible/local.yml
+++ b/ansible/local.yml
@@ -22,6 +22,7 @@
 # - import_playbook: includes/node-exporter.yml
 - import_playbook: includes/actual-server.yml
 - import_playbook: includes/vaultwarden.yml
+- import_playbook: includes/nut.yml
 - import_playbook: includes/homeassistant.yml
 # - import_playbook: includes/rclone.yml
 - import_playbook: includes/netdata.yml

--- a/ansible/templates/nut/nut.conf.j2
+++ b/ansible/templates/nut/nut.conf.j2
@@ -1,0 +1,4 @@
+# {{ ansible_managed }}
+# MODE must have no spaces around '=' (sourced by init scripts).
+
+MODE=standalone

--- a/ansible/templates/nut/ups.conf.j2
+++ b/ansible/templates/nut/ups.conf.j2
@@ -1,0 +1,11 @@
+# {{ ansible_managed }}
+# Local APC Back-UPS connected over USB (usbhid-ups).
+
+maxretry = 3
+
+[apc]
+	driver = usbhid-ups
+	port = auto
+	vendorid = 051d
+	productid = 0002
+	desc = "APC Back-UPS ES USB"

--- a/ansible/templates/nut/upsd.conf.j2
+++ b/ansible/templates/nut/upsd.conf.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+# Listen on localhost so Home Assistant (host networking) can use the NUT integration.
+
+LISTEN 127.0.0.1 3493
+LISTEN ::1 3493

--- a/ansible/templates/nut/upsd.users.j2
+++ b/ansible/templates/nut/upsd.users.j2
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+
+[homeassistant]
+	password = {{ nut_password }}
+	upsmon slave
+
+[upsmon]
+	password = {{ nut_password }}
+	upsmon master

--- a/ansible/templates/nut/upsmon.conf.j2
+++ b/ansible/templates/nut/upsmon.conf.j2
@@ -1,0 +1,15 @@
+# {{ ansible_managed }}
+
+MONITOR apc@localhost 1 upsmon {{ nut_password }} master
+
+MINSUPPLIES 1
+SHUTDOWNCMD "/sbin/shutdown -h +0"
+NOTIFYCMD /etc/nut/notifycmd
+POLLFREQ 5
+POLLFREQALERT 5
+HOSTSYNC 15
+DEADTIME 15
+POWERDOWNFLAG /etc/killpower
+RBWARNTIME 43200
+NOCOMMWARNTIME 300
+FINALDELAY 5


### PR DESCRIPTION
## Summary
- Add host NUT playbook for the local APC Back-UPS over USB (`usbhid-ups`), listening on `127.0.0.1:3493`
- Remove the broken Home Assistant `/dev/ttyUSB0` device map (APC is USB HID, not serial)
- Fix invalid `when: - not ansible_check_mode` YAML in the Matter Server task

## Test plan
- [ ] Confirm ansible-pull applies `nut.yml` and `upsc apc@localhost` returns `ups.status: OL`
- [ ] Confirm Home Assistant container has no `/dev/ttyUSB0` device map
- [ ] In HA UI, add Network UPS Tools using credentials from `/root/nut_ha_connection.txt` on the host
- [ ] Verify battery/status entities appear in Home Assistant


Made with [Cursor](https://cursor.com)