### PR TITLE
Fix Traefik DNS override to use dns_servers

### DIFF
--- a/ansible/includes/traefik.yml
+++ b/ansible/includes/traefik.yml
@@ -93,7 +93,7 @@
           - /etc/timezone:/etc/timezone:ro
           - /etc/localtime:/etc/localtime:ro
         # Public resolvers: ACME DNS-01 must not depend on LAN DNS.
-        dns:
+        dns_servers:
           - "1.1.1.1"
           - "1.0.0.1"
         etc_hosts:


### PR DESCRIPTION
## Summary
- Fix Traefik container DNS override to use Ansible `dns_servers` instead of unsupported `dns`
- Continues LAN-default DNS work: Traefik stays on Cloudflare for ACME while other containers use the LAN gateway

## Test plan
- [ ] `Deploy traefik container` task succeeds (no unsupported parameter error)
- [ ] `docker exec traefik cat /etc/resolv.conf` shows Cloudflare nameservers
- [ ] Other containers still resolve via LAN DNS from Docker daemon config


Made with [Cursor](https://cursor.com)