### PR TITLE
Include HA UI automation YAML includes in bootstrap config

### DIFF
--- a/ansible/templates/homeassistant/configuration.yaml.j2
+++ b/ansible/templates/homeassistant/configuration.yaml.j2
@@ -4,6 +4,11 @@
 # Loads default set of integrations. Do not remove.
 default_config:
 
+# UI-managed automations / scripts / scenes
+automation: !include automations.yaml
+script: !include scripts.yaml
+scene: !include scenes.yaml
+
 http:
   use_x_forwarded_for: true
   trusted_proxies:


### PR DESCRIPTION
## Summary
- Add `automation` / `script` / `scene` `!include` lines to the Home Assistant bootstrap `configuration.yaml` template so UI-managed YAML files are loaded.
- Matches Home Assistant's default generated config; without these, `automations.yaml` on disk is ignored.

## Test plan
- [ ] Confirm template renders the three include lines
- [ ] On next, add the same includes to live `/opt/homeassistant/configuration.yaml` (ansible uses `force: false`) and create empty `scripts.yaml` / `scenes.yaml` if missing
- [ ] Check Configuration in HA, restart, verify existing automations load


Made with [Cursor](https://cursor.com)