### PR TITLE
Upgrade Ansible to 14.2 with FQCN

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,19 @@
+---
+profile: basic
+exclude_paths:
+  - .github/
+  - .collections/
+skip_list:
+  # Intentional package upgrades
+  - package-latest
+  # External roles cloned at runtime
+  - galaxy
+  # Pre-existing style; not required for Ansible 14 / FQCN upgrade
+  - name[casing]
+  - name[play]
+  - risky-file-permissions
+  - no-relative-paths
+  - key-order[task]
+warn_list:
+  - experimental
+  - jinja[spacing]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get -y install python3-docker python3-apt python3-debian
       - name: Install ansible $ANSIBLE_VERSION
-        run: pip install ansible==$ANSIBLE_VERSION
+        run: pip install ansible==$ANSIBLE_VERSION requests docker
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r requirements.yml
         working-directory: ./ansible

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,33 +12,40 @@ on:
 
 
 env:
-  PRE_COMMIT_VERSION: "2.16.0"
-  ANSIBLE_VERSION: "6.7.0"
+  PRE_COMMIT_VERSION: "4.6.1"
+  ANSIBLE_VERSION: "14.2.0"
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checking out repo
         uses: actions/checkout@v7
       - name: Setup Python
         uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - name: Install pre-commit $PRE_COMMIT_VERSION
         run: pip install pre-commit==$PRE_COMMIT_VERSION
       - name: Run pre-commit
         run: pre-commit run --all-files
   # Testing ansible-pull that is ran via cronjob
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checking out repo
         uses: actions/checkout@v7
       - name: Setup Python
         uses: actions/setup-python@v5
-      - name: Install python3-docker
-        run: sudo apt-get -y install python3-docker
+        with:
+          python-version: "3.12"
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get -y install python3-docker python3-apt python3-debian
       - name: Install ansible $ANSIBLE_VERSION
         run: pip install ansible==$ANSIBLE_VERSION
+      - name: Install Ansible collections
+        run: ansible-galaxy collection install -r requirements.yml
+        working-directory: ./ansible
       - name: Run Ansible test
         run: ansible-playbook --inventory '127.0.0.1,' --connection local --become --check local.yml -e digitalocean_host='*' -e digitalocean_domain='example.com' -e digitalocean_token='randomtoken' -e config_deploy=true -e config_file='/tmp/config.ini'
         working-directory: ./ansible

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,6 +46,17 @@ jobs:
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r requirements.yml
         working-directory: ./ansible
+      - name: Seed config.ini for check mode
+        # Template deploy is a no-op under --check, but later plays need these facts.
+        run: |
+          cat > /tmp/config.ini <<'EOF'
+          [digitalocean]
+          host = *
+          domain = example.com
+          token = randomtoken
+          [share]
+          allowed_ip =
+          EOF
       - name: Run Ansible test
         run: ansible-playbook --inventory '127.0.0.1,' --connection local --become --check local.yml -e digitalocean_host='*' -e digitalocean_domain='example.com' -e digitalocean_token='randomtoken' -e config_deploy=true -e config_file='/tmp/config.ini'
         working-directory: ./ansible

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -7,12 +7,13 @@ on:
   #   - cron: '0 0 * * 0'
   workflow_dispatch:
 
+
 env:
-  PRE_COMMIT_VERSION: "2.16.0"
+  PRE_COMMIT_VERSION: "4.6.1"
 
 jobs:
   autoupdate:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checking out repo
         uses: actions/checkout@v7
@@ -20,6 +21,8 @@ jobs:
           fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - name: Install pre-commit $PRE_COMMIT_VERSION
         run: pip install pre-commit==$PRE_COMMIT_VERSION
       - name: Run pre-commit autoupdate

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__
 *.swp
-ansible/setup.sh
+ansible/collections/
+.collections/
+.lint-out.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 fail_fast: true
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: fix-byte-order-marker
       - id: check-case-conflict
@@ -20,22 +20,24 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.29.0
+    rev: v1.38.0
     hooks:
       - id: yamllint
 
-  - repo: https://github.com/ansible-community/ansible-lint.git
-    rev: v6.11.0
+  - repo: https://github.com/ansible/ansible-lint.git
+    rev: v26.6.0
     hooks:
       - id: ansible-lint
         files: \.(yaml|yml)$
+        additional_dependencies:
+          - ansible==14.2.0
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.3.0
     hooks:
       - id: flake8
 
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 38.119.0
+    rev: 41.131.0
     hooks:
       - id: renovate-config-validator

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,8 @@ repos:
     hooks:
       - id: ansible-lint
         files: \.(yaml|yml)$
+        # Hook metadata defaults to python3.14; CI/local commonly have 3.12
+        language_version: python3.12
         additional_dependencies:
           - ansible==14.2.0
 

--- a/.yamllint
+++ b/.yamllint
@@ -3,6 +3,9 @@ extends: default
 
 ignore: |
   *vault*
+  .github/
 
 rules:
   line-length: disable
+  truthy:
+    allowed-values: ['true', 'false', 'on', 'off', 'yes', 'no']

--- a/README.md
+++ b/README.md
@@ -22,21 +22,17 @@ To enable healthchecks.io monitoring for the ansible-pull cronjob, run playbook 
 ansible-playbook -i '<hostname/ipaddress>,' ansible_pull.yml --user <username> --become --ask-become-pass -e healthchecks_uuid=<checkUUID> -e config_deploy=true
 ```
 
-To enable namecheap dynamic updates, first have your hostname registered. Then you can pass in required parameters to the pull playbook as below.
-```
-ansible-playbook -i '<hostname/ipaddress>,' ansible_pull.yml --user <username> --become --ask-become-pass -e namecheap_host=myhostname -e namecheap_domain=mydomain.tld -e namecheap_password=myrandompassword -e config_deploy=true
-```
-
 ## Running services
 
 Once the cronjob has been setup, there should be following available services provided by the server:
-- Emby
-- Pihole (+Unbound)
-- Grafana
-- Wireguard
-- Webui Aria2
-- HTTPs access to services (Traefik, Digitalocean)
-- NAS to external hdd backup - [Coming soon](https://github.com/ahmedsajid/home-setup/issues/32)
+- Jellyfin
+- Traefik (HTTPS / DigitalOcean DNS)
+- Home Assistant (+ Matter Server)
+- Vaultwarden
+- Actual Budget
+- Speedtest Tracker
+- Netdata
+- Network UPS Tools (NUT)
 
 ## Integrations
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Once the cronjob has been setup, there should be following available services pr
 - Home Assistant (+ Matter Server)
 - Vaultwarden
 - Actual Budget
-- Speedtest Tracker
 - Netdata
 - Network UPS Tools (NUT)
 

--- a/ansible/ansible_pull.yml
+++ b/ansible/ansible_pull.yml
@@ -123,7 +123,7 @@
     - name: going to deploy config
       ansible.builtin.debug:
         msg: "Deploying config"
-      when: (not config_exists.stat.exists) or (config_deploy is defined and config_deploy)
+      when: (not config_exists.stat.exists) or (config_deploy is defined and config_deploy | bool)
 
     - name: Deploy a config ini file
       ansible.builtin.template:
@@ -132,7 +132,7 @@
         owner: root
         group: root
         mode: "0644"
-      when: (not config_exists.stat.exists) or (config_deploy is defined and config_deploy)
+      when: (not config_exists.stat.exists) or (config_deploy is defined and config_deploy | bool)
 
     - name: Create crontab entry to clone/pull git repository
       ansible.builtin.template:

--- a/ansible/ansible_pull.yml
+++ b/ansible/ansible_pull.yml
@@ -26,37 +26,97 @@
     # ini config file with various secrets and parameters
     config_file: /root/config.ini
 
+    # Ansible 14+ requires Python >= 3.12 on the control node
+    ansible_python: python3.12
+
     # pip packages to be installed
     pip_packages:
-      - ansible==6.7.0
-      - ara==1.6.1
+      - ansible==14.2.0
+      - requests
   tasks:
     - name: Remove ansible version provided by package managers
-      package:
+      ansible.builtin.package:
         name: ansible
         state: absent
 
-    - name: Install python3-pip
-      package:
-        name: python3-pip
+    - name: Install OS packages needed for Python tooling
+      ansible.builtin.package:
+        name:
+          - python3-pip
+          - software-properties-common
         state: present
+
+    - name: Check whether Python 3.12 is available
+      ansible.builtin.command: "{{ ansible_python }} --version"
+      register: python312_check
+      changed_when: false
+      failed_when: false
+
+    - name: Add deadsnakes PPA when Python 3.12 is missing
+      ansible.builtin.deb822_repository:
+        name: deadsnakes-ppa
+        types: deb
+        uris: https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu
+        suites: "{{ ansible_distribution_release }}"
+        components: main
+        signed_by: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xF23C5A6CF475977595C89F51BA6932366A755776
+        install_python_debian: true
+        state: present
+      when: python312_check.rc != 0
+
+    - name: Refresh apt cache after adding deadsnakes
+      ansible.builtin.apt:
+        update_cache: true
+      when: python312_check.rc != 0
+
+    - name: Install Python 3.12
+      ansible.builtin.package:
+        name:
+          - python3.12
+          - python3.12-venv
+          - python3.12-dev
+        state: present
+      when: python312_check.rc != 0
+
+    - name: Ensure pip is available for Python 3.12
+      ansible.builtin.command: "{{ ansible_python }} -m ensurepip --upgrade"
+      register: ensurepip_result
+      changed_when: "'Successfully installed' in (ensurepip_result.stdout | default(''))"
+      failed_when: false
+
+    - name: Bootstrap pip via get-pip when ensurepip is unavailable
+      ansible.builtin.shell: |
+        set -euo pipefail
+        curl -fsSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
+        {{ ansible_python }} /tmp/get-pip.py
+      args:
+        executable: /bin/bash
+      when: ensurepip_result.rc | default(1) != 0
+      changed_when: true
 
     - name: Install via pip
-      pip:
-        name: "{{ item }}"
-        state: present
-      with_items: "{{ pip_packages }}"
+      ansible.builtin.command:
+        argv:
+          - "{{ ansible_python }}"
+          - "-m"
+          - "pip"
+          - "install"
+          - "--upgrade"
+          - "{{ item }}"
+      loop: "{{ pip_packages }}"
+      register: pip_install
+      changed_when: "'Successfully installed' in pip_install.stdout"
 
     - name: Create local directory to work from
-      file:
+      ansible.builtin.file:
         path: "{{ workdir }}"
         state: directory
         owner: root
         group: root
-        mode: 0751
+        mode: "0751"
 
     - name: Check if config file exists
-      stat:
+      ansible.builtin.stat:
         path: "{{ config_file }}"
       register: config_exists
 
@@ -66,26 +126,26 @@
       when: (not config_exists.stat.exists) or (config_deploy is defined and config_deploy)
 
     - name: Deploy a config ini file
-      template:
+      ansible.builtin.template:
         src: templates/root/config.ini.j2
         dest: "{{ config_file }}"
         owner: root
         group: root
-        mode: 0644
+        mode: "0644"
       when: (not config_exists.stat.exists) or (config_deploy is defined and config_deploy)
 
     - name: Create crontab entry to clone/pull git repository
-      template:
+      ansible.builtin.template:
         src: templates/etc/etc_cron.d_ansible-pull.j2
         dest: /etc/cron.d/ansible-pull
         owner: root
         group: root
-        mode: 0644
+        mode: "0644"
 
     - name: Create logrotate entry for ansible-pull.log
-      template:
+      ansible.builtin.template:
         src: templates/etc/etc_logrotate.d_ansible-pull.j2
         dest: /etc/logrotate.d/ansible-pull
         owner: root
         group: root
-        mode: 0644
+        mode: "0644"

--- a/ansible/includes/actual-server.yml
+++ b/ansible/includes/actual-server.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Read ini config file
-  import_playbook: "read_config_file.yml"
+  ansible.builtin.import_playbook: "read_config_file.yml"
 
 - name: "Actual Budget server setup"
   hosts: localhost
@@ -10,15 +10,15 @@
     actual_docker_image: "docker.io/actualbudget/actual-server:26.7.0"
   tasks:
     - name: create actual required folder
-      file:
+      ansible.builtin.file:
         state: directory
         path: "{{ item }}"
-      with_items:
+      loop:
         - "/opt/actual"
         - "/mnt/nas/Backup/actual"
 
     - name: Deploy actual container
-      docker_container:
+      community.docker.docker_container:
         name: "actual"
         hostname: "actual"
         image: "{{ actual_docker_image }}"
@@ -54,32 +54,32 @@
       when: not ansible_check_mode
 
     - name: Set today's actual backup path
-      set_fact:
+      ansible.builtin.set_fact:
         actual_backup_file: "/mnt/nas/Backup/actual/actual-backup-{{ ansible_date_time.date }}.tgz"
 
     - name: Check whether today's actual backup already exists
-      stat:
+      ansible.builtin.stat:
         path: "{{ actual_backup_file }}"
       register: actual_todays_backup
 
     - name: Run daily actual backup if missing
       block:
         - name: Create archive
-          archive:
+          community.general.archive:
             path: /opt/actual
             dest: "{{ actual_backup_file }}"
 
         - name: Find older backups
-          find:
+          ansible.builtin.find:
             paths: /mnt/nas/Backup/actual/
             age: 5d
             recurse: true
           register: actual_old_backups
 
         - name: Remove older backups
-          file:
+          ansible.builtin.file:
             path: "{{ item.path }}"
             state: absent
-          with_items: "{{ actual_old_backups.files }}"
+          loop: "{{ actual_old_backups.files }}"
       when: (not actual_todays_backup.stat.exists) or
             (force_actual_backup is defined and force_actual_backup | bool)

--- a/ansible/includes/common-packages.yml
+++ b/ansible/includes/common-packages.yml
@@ -5,23 +5,22 @@
   connection: local
   tasks:
     - name: install common-packages
-      package:
-        name: "{{ item }}"
-      with_items:
-        - "bash-completion"
-        - "net-tools"
-        - "iputils-ping"
-        - "curl"
-        - "wget"
-        - "screen"
-        - "tree"
-        - "jq"
-        - "aria2"
-        - "nmap"
-        - "whois"
+      ansible.builtin.package:
+        name:
+          - bash-completion
+          - net-tools
+          - iputils-ping
+          - curl
+          - wget
+          - screen
+          - tree
+          - jq
+          - nmap
+          - whois
+        state: present
 
     # Taken from https://rizvir.com/articles/linux-sysadmin-cheats/
     - name: Allow scrolling in screen session
-      lineinfile:
+      ansible.builtin.lineinfile:
         path: /etc/screenrc
         line: 'termcapinfo xterm* ti@:te@'

--- a/ansible/includes/digitalocean_dns.yml
+++ b/ansible/includes/digitalocean_dns.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Read ini config file
-  import_playbook: "read_config_file.yml"
+  ansible.builtin.import_playbook: "read_config_file.yml"
 
 - name: Dynamic Updates under DigitalOcean DNS
   hosts: localhost
@@ -10,16 +10,16 @@
     config_file: '/root/config.ini'
   tasks:
     - name: do not run in check mode - end_play
-      meta: end_play
+      ansible.builtin.meta: end_play
       when: ansible_check_mode
 
     - name: Install via pip
-      pip:
+      ansible.builtin.pip:
         name: "dnspython"
         state: present
 
     - name: Get IPv4 address
-      uri:
+      ansible.builtin.uri:
         url: "https://api.ipify.org?format=json"
         method: GET
         return_content: true
@@ -30,24 +30,22 @@
       delay: 5
 
     - name: Setting digital ocean facts
-      set_fact:
-        do_host: "{{ lookup('ini', 'host section=digitalocean file={{ config_file }}') }}"
-        do_token: "{{ lookup('ini', 'token section=digitalocean file={{ config_file }}') }}"
-        do_domain: "{{ lookup('ini', 'domain section=digitalocean file={{ config_file }}') | community.dns.get_registrable_domain }}"
+      ansible.builtin.set_fact:
+        do_host: "{{ lookup('ansible.builtin.ini', 'host section=digitalocean file={{ config_file }}') }}"
+        do_token: "{{ lookup('ansible.builtin.ini', 'token section=digitalocean file={{ config_file }}') }}"
+        do_domain: "{{ lookup('ansible.builtin.ini', 'domain section=digitalocean file={{ config_file }}') | community.dns.get_registrable_domain }}"
         dns_record_id: 0
 
     - name: Lookup existing record
-      set_fact:
-        dig_lookup: "{{ lookup('dig', do_host + '.' + do_domain, '@1.1.1.1') }}"
+      ansible.builtin.set_fact:
+        dig_lookup: "{{ lookup('community.general.dig', do_host + '.' + do_domain, '@1.1.1.1') }}"
 
     - name: stop play if config options do not exist or update isn't required
-      meta: end_play
-      when: do_host | length == 0 or do_domain | length == 0 or  do_token | length == 0 or dig_lookup == ipv4_result.json.ip
+      ansible.builtin.meta: end_play
+      when: do_host | length == 0 or do_domain | length == 0 or do_token | length == 0 or dig_lookup == ipv4_result.json.ip
 
     - name: Fetch existing record id
-      vars:
-        ip: "{{ ipv4_result.json.ip }}"
-      uri:
+      ansible.builtin.uri:
         url: "https://api.digitalocean.com/v2/domains/{{ do_domain }}/records"
         method: GET
         headers:
@@ -59,34 +57,27 @@
     - name: Get DNS record id
       vars:
         dns_record_query: "domain_records[?name=='{{ do_host }}'].id"
-      set_fact:
+      ansible.builtin.set_fact:
         dns_record_id: "{{ dns_records.json | json_query(dns_record_query) | first }}"
-      ignore_errors: true
+      failed_when: false
 
     - name: Setting fact for method and URL when record exists
-      set_fact:
+      ansible.builtin.set_fact:
         do_dns_method: "PATCH"
-        digitaloean_dns_url: "https://api.digitalocean.com/v2/domains/{{ do_domain }}/records/{{ dns_record_id }}"
+        digitalocean_dns_url: "https://api.digitalocean.com/v2/domains/{{ do_domain }}/records/{{ dns_record_id }}"
       when: dns_record_id | int > 0
 
     - name: Setting fact for method and URL when record doesn't exist
-      set_fact:
+      ansible.builtin.set_fact:
         do_dns_method: "POST"
-        digitaloean_dns_url: "https://api.digitalocean.com/v2/domains/{{ do_domain }}/records"
+        digitalocean_dns_url: "https://api.digitalocean.com/v2/domains/{{ do_domain }}/records"
       when: dns_record_id | int == 0
-
-    # EXAMPLE
-    # curl -X POST \
-    #   -H "Content-Type: application/json" \
-    #   -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-    #   -d '{"type":"A","name":"www","data":"162.10.66.0","priority":null,"port":null,"ttl":1800,"weight":null,"flags":null,"tag":null}' \
-    #   "https://api.digitalocean.com/v2/domains/example.com/records"
 
     - name: Update Dynamic DNS
       vars:
         ip: "{{ ipv4_result.json.ip }}"
-      uri:
-        url: "{{ digitaloean_dns_url }}"
+      ansible.builtin.uri:
+        url: "{{ digitalocean_dns_url }}"
         method: "{{ do_dns_method }}"
         body_format: json
         status_code: 200

--- a/ansible/includes/disablesleep.yml
+++ b/ansible/includes/disablesleep.yml
@@ -3,16 +3,13 @@
 - name: "Ensuring laptop stays awake"
   hosts: localhost
   connection: local
-  handlers:
-    - name: Update Grub
-      command: update-grub
   tasks:
     - name: "Disable any kind of sleep"
-      systemd:
+      ansible.builtin.systemd:
         name: "{{ item }}"
         enabled: false
         masked: true
-      with_items:
+      loop:
         - sleep.target
         - suspend.target
         - hibernate.target

--- a/ansible/includes/disableunattendedupgrdes.yml
+++ b/ansible/includes/disableunattendedupgrdes.yml
@@ -5,10 +5,10 @@
   connection: local
   tasks:
     - name: "Gather service facts"
-      service_facts:
+      ansible.builtin.service_facts:
 
     - name: "Disable unattended upgrades service"
-      systemd:
+      ansible.builtin.systemd:
         name: "unattended-upgrades.service"
         enabled: false
         masked: true

--- a/ansible/includes/dns.yml
+++ b/ansible/includes/dns.yml
@@ -11,12 +11,12 @@
       - "{{ ansible_default_ipv4.gateway }}"
   tasks:
     - name: create role folder
-      file:
+      ansible.builtin.file:
         state: directory
         path: /root/.ansible/roles
 
     - name: Clone role ahuffman.resolv
-      git:
+      ansible.builtin.git:
         repo: 'https://github.com/ahuffman/ansible-resolv.git'
         dest: /root/.ansible/roles/ahuffman.resolv
         version: "{{ resolv_role_version }}"
@@ -27,7 +27,7 @@
       until: result is succeeded
 
     - name: Using resolv role
-      include_role:
+      ansible.builtin.include_role:
         name: ahuffman.resolv
       vars:
         resolv_nameservers: "{{ lan_nameservers }}"
@@ -37,7 +37,7 @@
       when: not ansible_check_mode
 
     - name: "Disable systemd-resolv"
-      systemd:
+      ansible.builtin.systemd:
         name: "systemd-resolved"
         enabled: false
         masked: true

--- a/ansible/includes/docker.yml
+++ b/ansible/includes/docker.yml
@@ -3,24 +3,14 @@
 - name: "Docker installation and setup"
   hosts: localhost
   connection: local
-  handlers:
-    - name: Restart docker
-      systemd:
-        name: "docker"
-        state: restarted
-      # Skipping check mode since its causes issues :(
-      when: not ansible_check_mode
   tasks:
-    - name: Gather package facts
-      package_facts:
-
     - name: create role folder
-      file:
+      ansible.builtin.file:
         state: directory
         path: /root/.ansible/roles
 
     - name: Clone role gbolo.docker
-      git:
+      ansible.builtin.git:
         repo: 'https://github.com/gbolo/ansible-role-docker.git'
         dest: /root/.ansible/roles/gbolo.docker
         version: v2.1
@@ -31,7 +21,7 @@
       until: result is succeeded
 
     - name: Using docker role
-      include_role:
+      ansible.builtin.include_role:
         name: gbolo.docker
       vars:
         docker_config_log_opts: {
@@ -62,15 +52,11 @@
         docker_config_custom:
           "dns":
             - "{{ ansible_default_ipv4.gateway }}"
-          "runtimes":
-            "nvidia":
-              "path": "nvidia-container-runtime"
-              "runtimeArgs": []
           "live-restore": true
       when: not ansible_check_mode
 
     - name: Setup docker app network
-      docker_network:
+      community.docker.docker_network:
         name: app_network
         ipam_config:
           - subnet: '172.17.0.0/24'

--- a/ansible/includes/homeassistant.yml
+++ b/ansible/includes/homeassistant.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Read ini config file
-  import_playbook: "read_config_file.yml"
+  ansible.builtin.import_playbook: "read_config_file.yml"
 
 - name: "Home Assistant"
   hosts: localhost
@@ -11,16 +11,16 @@
     matter_server_docker_image: "ghcr.io/home-assistant-libs/python-matter-server:stable"
   tasks:
     - name: create homeassistant required folders
-      file:
+      ansible.builtin.file:
         state: directory
         path: "{{ item }}"
-      with_items:
+      loop:
         - "/opt/homeassistant"
         - "/opt/matter-server"
         - "/mnt/nas/Backup/homeassistant"
 
     - name: Deploy Matter Server container
-      docker_container:
+      community.docker.docker_container:
         name: "matter-server"
         hostname: "matter-server"
         image: "{{ matter_server_docker_image }}"
@@ -47,7 +47,7 @@
       when: not ansible_check_mode
 
     - name: Deploy homeassistant bootstrap config
-      template:
+      ansible.builtin.template:
         src: "../templates/homeassistant/configuration.yaml.j2"
         dest: "/opt/homeassistant/configuration.yaml"
         mode: 0644
@@ -55,7 +55,7 @@
       when: not ansible_check_mode
 
     - name: Deploy homeassistant container
-      docker_container:
+      community.docker.docker_container:
         name: "homeassistant"
         hostname: "homeassistant"
         image: "{{ homeassistant_docker_image }}"
@@ -94,32 +94,32 @@
       when: not ansible_check_mode
 
     - name: Set today's homeassistant backup path
-      set_fact:
+      ansible.builtin.set_fact:
         homeassistant_backup_file: "/mnt/nas/Backup/homeassistant/homeassistant-backup-{{ ansible_date_time.date }}.tgz"
 
     - name: Check whether today's homeassistant backup already exists
-      stat:
+      ansible.builtin.stat:
         path: "{{ homeassistant_backup_file }}"
       register: homeassistant_todays_backup
 
     - name: Run daily homeassistant backup if missing
       block:
         - name: Create archive
-          archive:
+          community.general.archive:
             path: /opt/homeassistant
             dest: "{{ homeassistant_backup_file }}"
 
         - name: Find older backups
-          find:
+          ansible.builtin.find:
             paths: /mnt/nas/Backup/homeassistant/
             age: 5d
             recurse: true
           register: homeassistant_old_backups
 
         - name: Remove older backups
-          file:
+          ansible.builtin.file:
             path: "{{ item.path }}"
             state: absent
-          with_items: "{{ homeassistant_old_backups.files }}"
+          loop: "{{ homeassistant_old_backups.files }}"
       when: (not homeassistant_todays_backup.stat.exists) or
             (force_homeassistant_backup is defined and force_homeassistant_backup | bool)

--- a/ansible/includes/homeassistant.yml
+++ b/ansible/includes/homeassistant.yml
@@ -84,8 +84,8 @@
           - '/opt/homeassistant:/config'
           - '/etc/localtime:/etc/localtime:ro'
           - '/run/dbus:/run/dbus:ro'
-        # APC UPS is owned by host NUT (nut.yml). HA uses the NUT integration
-        # against 127.0.0.1:3493 via host networking — no USB device map needed.
+      # APC UPS is owned by host NUT (nut.yml). HA uses the NUT integration
+      # against 127.0.0.1:3493 via host networking — no USB device map needed.
       # added retry to tasks dependant on external services
       register: result
       retries: 5

--- a/ansible/includes/jellyfin.yml
+++ b/ansible/includes/jellyfin.yml
@@ -68,6 +68,7 @@
       ansible.builtin.dpkg_selections:
         name: jellyfin
         selection: hold
+      when: not ansible_check_mode
 
     - name: Install VA-API drivers for Intel hardware transcoding
       ansible.builtin.apt:

--- a/ansible/includes/jellyfin.yml
+++ b/ansible/includes/jellyfin.yml
@@ -12,29 +12,40 @@
       - network.xml
 
   tasks:
-    - name: Add an Apt signing key for Jellyfin
-      apt_key:
-        url: https://repo.jellyfin.org/jellyfin_team.gpg.key
+    - name: Ensure python3-debian is available for deb822 repos
+      ansible.builtin.package:
+        name: python3-debian
         state: present
+
+    - name: Remove legacy Jellyfin apt list file
+      ansible.builtin.file:
+        path: /etc/apt/sources.list.d/jellyfin.list
+        state: absent
 
     - name: Add Jellyfin repository
-      apt_repository:
-        repo: deb [arch=amd64] https://repo.jellyfin.org/ubuntu focal main
+      ansible.builtin.deb822_repository:
+        name: jellyfin
+        types: deb
+        uris: https://repo.jellyfin.org/ubuntu
+        suites: focal
+        components: main
+        architectures: amd64
+        signed_by: https://repo.jellyfin.org/jellyfin_team.gpg.key
         state: present
-        filename: jellyfin
 
     - name: Get Jellyfin installed version
-      shell:
+      ansible.builtin.shell:
         cmd: dpkg-query -f '${Version}' -W jellyfin
       register: dpkg_query_jellyfin_version
-      ignore_errors: true
+      failed_when: false
+      changed_when: false
 
     - name: Setting jellyfin_installed_version fact
-      set_fact:
+      ansible.builtin.set_fact:
         jellyfin_installed_version: "{{ dpkg_query_jellyfin_version.stdout | default('') }}"
 
     - name: Allow jellyfin to be upgraded
-      dpkg_selections:
+      ansible.builtin.dpkg_selections:
         name: jellyfin
         selection: install
       when:
@@ -42,7 +53,7 @@
         - not ansible_check_mode
 
     - name: Install Jellyfin
-      apt:
+      ansible.builtin.apt:
         name: "jellyfin={{ jellyfin_version }}"
         update_cache: true
         allow_change_held_packages: false
@@ -54,33 +65,34 @@
         - not ansible_check_mode
 
     - name: Prevent jellyfin from being upgraded
-      dpkg_selections:
+      ansible.builtin.dpkg_selections:
         name: jellyfin
         selection: hold
 
     - name: Install VA-API drivers for Intel hardware transcoding
-      apt:
+      ansible.builtin.apt:
         name:
           - i965-va-driver
           - mesa-va-drivers
         state: present
 
     - name: Check prime-select profile
-      command: prime-select query
+      ansible.builtin.command: prime-select query
       register: prime_profile
       changed_when: false
       failed_when: false
       when: not ansible_check_mode
 
     - name: Use Intel GPU for VA-API on Optimus laptops
-      command: prime-select intel
+      ansible.builtin.command: prime-select intel
+      changed_when: true
       when:
         - not ansible_check_mode
         - prime_profile.stdout is defined
         - prime_profile.stdout != "intel"
 
     - name: Ensure Jellyfin server is enabled
-      systemd:
+      ansible.builtin.systemd:
         name: "jellyfin"
         enabled: true
         state: started
@@ -88,14 +100,14 @@
       when: not ansible_check_mode
 
     - name: Create folders for content
-      file:
+      ansible.builtin.file:
         state: directory
         path: "{{ jellyfin_root }}"
         owner: "jellyfin"
         group: "jellyfin"
 
     - name: Check whether system config files need updating
-      copy:
+      ansible.builtin.copy:
         src: "../files/jellyfin/{{ item }}"
         dest: "/etc/jellyfin/{{ item }}"
         owner: "jellyfin"
@@ -106,7 +118,7 @@
       when: not ansible_check_mode
 
     - name: Check whether library configuration needs updating
-      synchronize:
+      ansible.posix.synchronize:
         src: "../files/jellyfin/default"
         dest: "{{ jellyfin_root }}"
         delete: true
@@ -119,18 +131,18 @@
       when: not ansible_check_mode
 
     - name: Determine whether Jellyfin service cycle is required
-      set_fact:
+      ansible.builtin.set_fact:
         jellyfin_config_changed: "{{ jellyfin_config_check.results | selectattr('changed') | list | length > 0 }}"
         jellyfin_library_changed: "{{ jellyfin_library_check.changed | default(false) }}"
       when: not ansible_check_mode
 
     - name: Set Jellyfin service cycle flag
-      set_fact:
+      ansible.builtin.set_fact:
         jellyfin_service_cycle_needed: "{{ jellyfin_config_changed or jellyfin_library_changed }}"
       when: not ansible_check_mode
 
     - name: Stop Jellyfin before applying configuration
-      systemd:
+      ansible.builtin.systemd:
         name: "jellyfin"
         state: stopped
       when:
@@ -138,7 +150,7 @@
         - jellyfin_service_cycle_needed | bool
 
     - name: Copy over system config file
-      copy:
+      ansible.builtin.copy:
         src: "../files/jellyfin/{{ item }}"
         dest: "/etc/jellyfin/{{ item }}"
         owner: "jellyfin"
@@ -149,7 +161,7 @@
         - jellyfin_service_cycle_needed | bool
 
     - name: Copy over library content configuration files
-      synchronize:
+      ansible.posix.synchronize:
         src: "../files/jellyfin/default"
         dest: "{{ jellyfin_root }}"
         delete: true
@@ -163,11 +175,11 @@
         - jellyfin_library_changed | bool
 
     - name: fixing permission of files that were copied
-      file:
+      ansible.builtin.file:
         path: "{{ jellyfin_root }}"
         state: directory
         recurse: true
-        mode: 0755
+        mode: "0755"
         owner: "jellyfin"
         group: "jellyfin"
       when:
@@ -176,7 +188,7 @@
         - jellyfin_library_changed | bool
 
     - name: Start Jellyfin after applying configuration
-      systemd:
+      ansible.builtin.systemd:
         name: "jellyfin"
         enabled: true
         state: started

--- a/ansible/includes/nasmounts.yml
+++ b/ansible/includes/nasmounts.yml
@@ -17,22 +17,22 @@
     nfs_mount_opts: 'rsize=32768,wsize=32768,nfsvers=3,tcp,async'
   tasks:
     - name: Installed nfs-common
-      package:
+      ansible.builtin.package:
         name: nfs-common
 
     - name: Create required folders
-      file:
+      ansible.builtin.file:
         state: directory
         path: "{{ nas_root }}/{{ item }}"
-      with_items: "{{ mounts }}"
+      loop: "{{ mounts }}"
 
     - name: Adding NAS mount points to fstab
-      mount:
+      ansible.posix.mount:
         src: "nas.{{ do_domain }}:/{{ item }}"
         path: "{{ nas_root }}/{{ item }}"
         fstype: nfs
         state: mounted
         opts: "{{ nfs_mount_opts }}"
-      with_items: "{{ mounts }}"
+      loop: "{{ mounts }}"
       when:
         - not ansible_check_mode

--- a/ansible/includes/netdata.yml
+++ b/ansible/includes/netdata.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Read ini config file
-  import_playbook: "read_config_file.yml"
+  ansible.builtin.import_playbook: "read_config_file.yml"
 
 - name: "netdata Install and setup"
   hosts: localhost
@@ -10,17 +10,17 @@
     netdata_docker_image: "docker.io/netdata/netdata:v2.10.4"
   tasks:
     - name: create netdata required folders
-      file:
+      ansible.builtin.file:
         state: directory
         path: "{{ item }}"
         recurse: true
-      with_items:
+      loop:
         - "/opt/netdata/etc"
         - "/opt/netdata/lib"
         - "/opt/netdata/cache"
 
     - name: Deploy netdata
-      docker_container:
+      community.docker.docker_container:
         name: "netdata"
         hostname: "netdata"
         image: "{{ netdata_docker_image }}"

--- a/ansible/includes/nut.yml
+++ b/ansible/includes/nut.yml
@@ -5,17 +5,18 @@
   connection: local
   handlers:
     - name: Restart nut
-      shell: |
+      ansible.builtin.shell: |
         upsdrvctl stop || true
         systemctl restart nut-server
         upsdrvctl start
         systemctl restart nut-monitor
       args:
         executable: /bin/bash
+      changed_when: true
       when: not ansible_check_mode
   tasks:
     - name: Install NUT packages
-      package:
+      ansible.builtin.package:
         name:
           - nut
           - nut-client
@@ -23,11 +24,11 @@
         state: present
 
     - name: Generate NUT password
-      set_fact:
-        nut_password: "{{ lookup('password', '/root/nut_password length=24 chars=ascii_letters,digits') }}"
+      ansible.builtin.set_fact:
+        nut_password: "{{ lookup('ansible.builtin.password', '/root/nut_password length=24 chars=ascii_letters,digits') }}"
 
     - name: Deploy NUT configuration
-      template:
+      ansible.builtin.template:
         src: "{{ item.src }}"
         dest: "{{ item.dest }}"
         owner: root
@@ -42,7 +43,7 @@
       notify: Restart nut
 
     - name: Enable and start NUT services
-      systemd:
+      ansible.builtin.systemd:
         name: "{{ item }}"
         enabled: true
         state: started
@@ -52,14 +53,14 @@
       when: not ansible_check_mode
 
     - name: Ensure UPS drivers are running
-      command: upsdrvctl start
+      ansible.builtin.command: upsdrvctl start
       register: upsdrvctl_start
       changed_when: false
       failed_when: false
       when: not ansible_check_mode
 
     - name: Verify APC UPS is readable via NUT
-      command: upsc apc@localhost
+      ansible.builtin.command: upsc apc@localhost
       register: upsc_apc
       changed_when: false
       retries: 5
@@ -68,14 +69,14 @@
       when: not ansible_check_mode
 
     - name: Show APC UPS status summary
-      debug:
+      ansible.builtin.debug:
         msg: "{{ upsc_apc.stdout_lines | select('match', '^(battery.charge|ups.status|ups.model|device.serial):') | list }}"
       when:
         - not ansible_check_mode
         - upsc_apc is succeeded
 
     - name: Write Home Assistant NUT connection hints
-      copy:
+      ansible.builtin.copy:
         dest: /root/nut_ha_connection.txt
         mode: "0600"
         content: |

--- a/ansible/includes/nut.yml
+++ b/ansible/includes/nut.yml
@@ -35,11 +35,11 @@
         group: nut
         mode: "0640"
       loop:
-        - { src: "../templates/nut/nut.conf.j2", dest: "/etc/nut/nut.conf" }
-        - { src: "../templates/nut/ups.conf.j2", dest: "/etc/nut/ups.conf" }
-        - { src: "../templates/nut/upsd.conf.j2", dest: "/etc/nut/upsd.conf" }
-        - { src: "../templates/nut/upsd.users.j2", dest: "/etc/nut/upsd.users" }
-        - { src: "../templates/nut/upsmon.conf.j2", dest: "/etc/nut/upsmon.conf" }
+        - {src: "../templates/nut/nut.conf.j2", dest: "/etc/nut/nut.conf"}
+        - {src: "../templates/nut/ups.conf.j2", dest: "/etc/nut/ups.conf"}
+        - {src: "../templates/nut/upsd.conf.j2", dest: "/etc/nut/upsd.conf"}
+        - {src: "../templates/nut/upsd.users.j2", dest: "/etc/nut/upsd.users"}
+        - {src: "../templates/nut/upsmon.conf.j2", dest: "/etc/nut/upsmon.conf"}
       notify: Restart nut
 
     - name: Enable and start NUT services

--- a/ansible/includes/nut.yml
+++ b/ansible/includes/nut.yml
@@ -26,6 +26,12 @@
     - name: Generate NUT password
       ansible.builtin.set_fact:
         nut_password: "{{ lookup('ansible.builtin.password', '/root/nut_password length=24 chars=ascii_letters,digits') }}"
+      when: not ansible_check_mode
+
+    - name: Use placeholder NUT password in check mode
+      ansible.builtin.set_fact:
+        nut_password: "check-mode-placeholder"
+      when: ansible_check_mode
 
     - name: Deploy NUT configuration
       ansible.builtin.template:

--- a/ansible/includes/os_update.yml
+++ b/ansible/includes/os_update.yml
@@ -5,30 +5,24 @@
   connection: local
   tasks:
     - name: "Set facts for time"
-      set_fact:
+      ansible.builtin.set_fact:
         hour_now: "{{ ansible_date_time.hour | int }}"
         minute_now: "{{ ansible_date_time.minute | int }}"
-
-    - name: "print ansible_date_time"
-      debug:
-        msg:
-          - "{{ hour_now }}"
-          - "{{ minute_now }}"
 
     - name: run os update and reboot if required
       block:
         - name: "update all packages"
-          apt:
+          ansible.builtin.apt:
             name: "*"
             state: latest
 
         - name: "check if reboot is required"
-          stat:
+          ansible.builtin.stat:
             path: /var/run/reboot-required
           register: reboot_required
 
         - name: "Reboot"
-          shell: sleep 5 && reboot &
+          ansible.builtin.shell: sleep 5 && reboot &
           async: 1
           poll: 0
           when: reboot_required.stat.exists

--- a/ansible/includes/read_config_file.yml
+++ b/ansible/includes/read_config_file.yml
@@ -7,20 +7,20 @@
     config_file: '/root/config.ini'
   tasks:
     - name: Check if config file exists
-      stat:
+      ansible.builtin.stat:
         path: "{{ config_file }}"
       register: config_file_exists
 
     - name: stop play if config file doesn't exist
-      meta: end_play
+      ansible.builtin.meta: end_play
       when: not config_file_exists.stat.exists
 
     - name: Setting digital ocean facts
-      set_fact:
-        do_host: "{{ lookup('ini', 'host section=digitalocean file={{ config_file }}') }}"
-        do_token: "{{ lookup('ini', 'token section=digitalocean file={{ config_file }}') }}"
-        do_domain: "{{ lookup('ini', 'domain section=digitalocean file={{ config_file }}') }}"
-        share_allowed_ip: "{{ lookup('ini', 'allowed_ip section=share file={{ config_file }}', errors='ignore') | default('', true) | trim }}"
+      ansible.builtin.set_fact:
+        do_host: "{{ lookup('ansible.builtin.ini', 'host section=digitalocean file={{ config_file }}') }}"
+        do_token: "{{ lookup('ansible.builtin.ini', 'token section=digitalocean file={{ config_file }}') }}"
+        do_domain: "{{ lookup('ansible.builtin.ini', 'domain section=digitalocean file={{ config_file }}') }}"
+        share_allowed_ip: "{{ lookup('ansible.builtin.ini', 'allowed_ip section=share file={{ config_file }}', errors='ignore') | default('', true) | trim }}"
         traefik_private_ranges:
           - "10.0.0.0/8"
           - "172.16.0.0/12"

--- a/ansible/includes/timezone.yml
+++ b/ansible/includes/timezone.yml
@@ -5,5 +5,5 @@
   connection: local
   tasks:
     - name: Setting timezone
-      timezone:
+      community.general.timezone:
         name: 'America/Toronto'

--- a/ansible/includes/traefik.yml
+++ b/ansible/includes/traefik.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Read ini config file
-  import_playbook: "read_config_file.yml"
+  ansible.builtin.import_playbook: "read_config_file.yml"
 
 # All HTTPS docker routers must define *-iprestrict middleware on the same container.
 # Blocked IPs get 404 (stealth). Exception: jellyfin (+ optional [share] allowed_ip).
@@ -14,22 +14,22 @@
     traefik_docker_image: "docker.io/traefik:v3.7.9"
   tasks:
     - name: create traefik required folders
-      file:
+      ansible.builtin.file:
         state: directory
         path: "{{ item }}"
-        mode: 0640
-      with_items:
+        mode: "0640"
+      loop:
         - "/opt/traefik/"
         - "/opt/traefik/dynamic"
 
     - name: Deploy traefik dynamic config for host services
-      template:
+      ansible.builtin.template:
         src: "../templates/traefik/dynamic.yml.j2"
         dest: "/opt/traefik/dynamic/host-services.yml"
-        mode: 0640
+        mode: "0640"
 
     - name: Deploy traefik container
-      docker_container:
+      community.docker.docker_container:
         name: "traefik"
         hostname: "traefik"
         image: "{{ traefik_docker_image }}"

--- a/ansible/includes/vaultwarden.yml
+++ b/ansible/includes/vaultwarden.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Read ini config file
-  import_playbook: "read_config_file.yml"
+  ansible.builtin.import_playbook: "read_config_file.yml"
 
 - name: "Vault Warden"
   hosts: localhost
@@ -10,15 +10,15 @@
     vaultwarden_docker_image: "vaultwarden/server:1.37.0"
   tasks:
     - name: create vaultwarden required folder
-      file:
+      ansible.builtin.file:
         state: directory
         path: "{{ item }}"
-      with_items:
+      loop:
         - "/opt/vaultwarden"
         - "/mnt/nas/Backup/vaultwarden"
 
     - name: Deploy vaultwarden container
-      docker_container:
+      community.docker.docker_container:
         name: "vaultwarden"
         hostname: "vaultwarden"
         image: "{{ vaultwarden_docker_image }}"
@@ -55,32 +55,32 @@
         - not ansible_check_mode
 
     - name: Set today's vaultwarden backup path
-      set_fact:
+      ansible.builtin.set_fact:
         vaultwarden_backup_file: "/mnt/nas/Backup/vaultwarden/vaultwarden-backup-{{ ansible_date_time.date }}.tgz"
 
     - name: Check whether today's vaultwarden backup already exists
-      stat:
+      ansible.builtin.stat:
         path: "{{ vaultwarden_backup_file }}"
       register: vaultwarden_todays_backup
 
     - name: Run daily vaultwarden backup if missing
       block:
         - name: Create archive
-          archive:
+          community.general.archive:
             path: /opt/vaultwarden
             dest: "{{ vaultwarden_backup_file }}"
 
         - name: Find older backups
-          find:
+          ansible.builtin.find:
             paths: /mnt/nas/Backup/vaultwarden/
             age: 5d
             recurse: true
           register: vaultwarden_old_backups
 
         - name: Remove older backups
-          file:
+          ansible.builtin.file:
             path: "{{ item.path }}"
             state: absent
-          with_items: "{{ vaultwarden_old_backups.files }}"
+          loop: "{{ vaultwarden_old_backups.files }}"
       when: (not vaultwarden_todays_backup.stat.exists) or
             (force_vaultwarden_backup is defined and force_vaultwarden_backup | bool)

--- a/ansible/local.yml
+++ b/ansible/local.yml
@@ -1,20 +1,20 @@
 ---
 
 # List of tasks
-- import_playbook: ansible_pull.yml
-- import_playbook: includes/digitalocean_dns.yml
-- import_playbook: includes/dns.yml
-- import_playbook: includes/disablesleep.yml
-- import_playbook: includes/disableunattendedupgrdes.yml
-- import_playbook: includes/timezone.yml
-- import_playbook: includes/common-packages.yml
-- import_playbook: includes/docker.yml
-- import_playbook: includes/traefik.yml
-- import_playbook: includes/nasmounts.yml
-- import_playbook: includes/jellyfin.yml
-- import_playbook: includes/actual-server.yml
-- import_playbook: includes/vaultwarden.yml
-- import_playbook: includes/nut.yml
-- import_playbook: includes/homeassistant.yml
-- import_playbook: includes/netdata.yml
-- import_playbook: includes/os_update.yml
+- ansible.builtin.import_playbook: ansible_pull.yml
+- ansible.builtin.import_playbook: includes/digitalocean_dns.yml
+- ansible.builtin.import_playbook: includes/dns.yml
+- ansible.builtin.import_playbook: includes/disablesleep.yml
+- ansible.builtin.import_playbook: includes/disableunattendedupgrdes.yml
+- ansible.builtin.import_playbook: includes/timezone.yml
+- ansible.builtin.import_playbook: includes/common-packages.yml
+- ansible.builtin.import_playbook: includes/docker.yml
+- ansible.builtin.import_playbook: includes/traefik.yml
+- ansible.builtin.import_playbook: includes/nasmounts.yml
+- ansible.builtin.import_playbook: includes/jellyfin.yml
+- ansible.builtin.import_playbook: includes/actual-server.yml
+- ansible.builtin.import_playbook: includes/vaultwarden.yml
+- ansible.builtin.import_playbook: includes/nut.yml
+- ansible.builtin.import_playbook: includes/homeassistant.yml
+- ansible.builtin.import_playbook: includes/netdata.yml
+- ansible.builtin.import_playbook: includes/os_update.yml

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,10 @@
+---
+collections:
+  - name: community.docker
+    version: ">=4.0.0"
+  - name: community.general
+    version: ">=10.0.0"
+  - name: community.dns
+    version: ">=3.0.0"
+  - name: ansible.posix
+    version: ">=1.5.0"

--- a/ansible/templates/etc/etc_cron.d_ansible-pull.j2
+++ b/ansible/templates/etc/etc_cron.d_ansible-pull.j2
@@ -3,9 +3,6 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 ANSIBLE_CONFIG={{ config_file }}
-ARA_API_CLIENT="http"
-ARA_API_SERVER="http://127.0.0.1:8000"
-ANSIBLE_CALLBACK_PLUGINS="$(python3 -m ara.setup.callback_plugins)"
 
 {{ schedule }} {{ cron_user }} ansible-pull --clean --directory {{ workdir }} --url {{ repo_url }} --checkout {{ checkout }} --extra-vars target=localhost ansible/local.yml >>{{ logfile }} 2>&1
 {{ dns_schedule }} {{ cron_user }} ansible-pull --directory {{ workdir }} --url {{ repo_url }} --checkout {{ checkout }} --extra-vars target=localhost ansible/includes/digitalocean_dns.yml >>{{ logfile }} 2>&1

--- a/ansible/templates/root/config.ini.j2
+++ b/ansible/templates/root/config.ini.j2
@@ -3,7 +3,7 @@
 [defaults]
 
 # callbacks
-callback_enabled = healthchecks, profile_tasks, ara
+callbacks_enabled = healthchecks, profile_tasks
 
 [callback_healthchecks]
 uuid = {{ healthchecks_uuid | default('') }}


### PR DESCRIPTION
## Summary
- Upgrade bootstrap/CI from Ansible 6.7.0 to **14.2.0** (requires Python 3.12+; bootstrap installs it via deadsnakes when missing)
- Convert playbooks/modules/lookups/import_playbook to FQCN; add ansible/requirements.yml for collection deps
- Replace deprecated apt_key with deb822_repository; drop ARA client wiring (no server was deployed)
- Remove unused handlers/package_facts/nvidia runtime leftover, refresh README/services list, bump CI to ubuntu-24.04 + current pre-commit/ansible-lint

## Test plan
- [ ] Re-run ansible_pull.yml on a host so Python 3.12 + Ansible 14.2 install
- [ ] Confirm cron still runs ansible-pull successfully
- [ ] CI lint + check-mode jobs pass
- [ ] Spot-check one container service play (e.g. Traefik/HA) after upgrade
- [ ] Confirm healthchecks callback still pings when UUID is set (requests installed)