### PR TITLE
Fix undefined nas_root by loading nas.yml via vars_files

### DIFF
--- a/ansible/includes/jellyfin.yml
+++ b/ansible/includes/jellyfin.yml
@@ -3,6 +3,8 @@
 - name: "Install and Setup Jellyfin"
   hosts: localhost
   connection: local
+  vars_files:
+    - "{{ playbook_dir }}/../group_vars/all/nas.yml"
   vars:
     jellyfin_root: "/var/lib/jellyfin/root"
     jellyfin_version: "10.11.11+ubu2004"

--- a/ansible/includes/nasmounts.yml
+++ b/ansible/includes/nasmounts.yml
@@ -3,6 +3,8 @@
 - name: "Ensuring NAS shares are mounted"
   hosts: localhost
   connection: local
+  vars_files:
+    - "{{ playbook_dir }}/../group_vars/all/nas.yml"
   vars:
     mounts:
       - 'Movies'

--- a/ansible/includes/pinchflat.yml
+++ b/ansible/includes/pinchflat.yml
@@ -6,6 +6,8 @@
 - name: "Pinchflat"
   hosts: localhost
   connection: local
+  vars_files:
+    - "{{ playbook_dir }}/../group_vars/all/nas.yml"
   vars:
     pinchflat_docker_image: "ghcr.io/kieraneglin/pinchflat:v2025.9.26"
     pinchflat_root: "/opt/pinchflat"


### PR DESCRIPTION
## Summary
- Explicitly load `group_vars/all/nas.yml` in `nasmounts`, `pinchflat`, and `jellyfin` plays
- Fixes `nas_root is undefined` under ansible-pull (same pattern as Traefik)

## Test plan
- [ ] ansible-pull / playbook gets past `Create required folders` in nasmounts
- [ ] Pinchflat and Jellyfin YouTube path tasks resolve `pinchflat_output_dir` / `pinchflat_shows_dir`


Made with [Cursor](https://cursor.com)