### PR TITLE
Fix Pinchflat image tag (manifest unknown)

### DIFF
--- a/ansible/includes/pinchflat.yml
+++ b/ansible/includes/pinchflat.yml
@@ -9,7 +9,7 @@
   vars_files:
     - "{{ playbook_dir }}/../group_vars/all/nas.yml"
   vars:
-    pinchflat_docker_image: "ghcr.io/kieraneglin/pinchflat:v2025.9.26"
+    pinchflat_docker_image: "ghcr.io/kieraneglin/pinchflat:latest"
     pinchflat_root: "/opt/pinchflat"
   tasks:
     - name: "Set facts for time"


### PR DESCRIPTION
## Summary
- Switch Pinchflat image from missing `ghcr.io/kieraneglin/pinchflat:v2025.9.26` to `latest`
- GHCR has no `v2025.9.26` manifest (404); `latest` matches the current release publish

## Test plan
- [ ] `docker pull ghcr.io/kieraneglin/pinchflat:latest` succeeds on next
- [ ] ansible Pinchflat deploy task starts the container


Made with [Cursor](https://cursor.com)