### PR TITLE
Fix Jellyfin YouTube library not scanning Pinchflat media

### DIFF
--- a/ansible/includes/jellyfin.yml
+++ b/ansible/includes/jellyfin.yml
@@ -12,9 +12,7 @@
       - system.xml
       - encoding.xml
       - network.xml
-    jellyfin_youtube_library_templates:
-      - src: YouTube.mblink.j2
-        dest: YouTube.mblink
+    jellyfin_youtube_library_files:
       - src: options.xml.j2
         dest: options.xml
 
@@ -141,22 +139,43 @@
       register: jellyfin_library_check
       when: not ansible_check_mode
 
-    - name: Check whether YouTube library templates need updating
+    - name: Check whether YouTube library mblink needs updating
+      copy:
+        content: "{{ pinchflat_shows_dir }}"
+        dest: "{{ jellyfin_root }}/default/YouTube/YouTube.mblink"
+        owner: "jellyfin"
+        group: "jellyfin"
+      check_mode: true
+      register: jellyfin_youtube_mblink_check
+      when: not ansible_check_mode
+
+    - name: Check whether YouTube collection marker needs updating
+      copy:
+        content: ""
+        dest: "{{ jellyfin_root }}/default/YouTube/tvshows.collection"
+        owner: "jellyfin"
+        group: "jellyfin"
+        force: false
+      check_mode: true
+      register: jellyfin_youtube_collection_check
+      when: not ansible_check_mode
+
+    - name: Check whether YouTube library options need updating
       template:
         src: "../templates/jellyfin/YouTube/{{ item.src }}"
         dest: "{{ jellyfin_root }}/default/YouTube/{{ item.dest }}"
         owner: "jellyfin"
         group: "jellyfin"
       check_mode: true
-      register: jellyfin_youtube_check
-      loop: "{{ jellyfin_youtube_library_templates }}"
+      register: jellyfin_youtube_options_check
+      loop: "{{ jellyfin_youtube_library_files }}"
       when: not ansible_check_mode
 
     - name: Determine whether Jellyfin service cycle is required
       set_fact:
         jellyfin_config_changed: "{{ jellyfin_config_check.results | selectattr('changed') | list | length > 0 }}"
         jellyfin_library_changed: "{{ jellyfin_library_check.changed | default(false) }}"
-        jellyfin_youtube_changed: "{{ jellyfin_youtube_check.results | selectattr('changed') | list | length > 0 }}"
+        jellyfin_youtube_changed: "{{ (jellyfin_youtube_mblink_check.changed | default(false)) or (jellyfin_youtube_collection_check.changed | default(false)) or (jellyfin_youtube_options_check.results | default([]) | selectattr('changed') | list | length > 0) }}"
       when: not ansible_check_mode
 
     - name: Set Jellyfin service cycle flag
@@ -207,13 +226,34 @@
         - not ansible_check_mode
         - jellyfin_service_cycle_needed | bool
 
-    - name: Deploy YouTube library templates
+    - name: Deploy YouTube library mblink without trailing newline
+      copy:
+        content: "{{ pinchflat_shows_dir }}"
+        dest: "{{ jellyfin_root }}/default/YouTube/YouTube.mblink"
+        owner: "jellyfin"
+        group: "jellyfin"
+      when:
+        - not ansible_check_mode
+        - jellyfin_service_cycle_needed | bool
+
+    - name: Deploy YouTube tvshows collection marker
+      copy:
+        content: ""
+        dest: "{{ jellyfin_root }}/default/YouTube/tvshows.collection"
+        owner: "jellyfin"
+        group: "jellyfin"
+        force: false
+      when:
+        - not ansible_check_mode
+        - jellyfin_service_cycle_needed | bool
+
+    - name: Deploy YouTube library options template
       template:
         src: "../templates/jellyfin/YouTube/{{ item.src }}"
         dest: "{{ jellyfin_root }}/default/YouTube/{{ item.dest }}"
         owner: "jellyfin"
         group: "jellyfin"
-      loop: "{{ jellyfin_youtube_library_templates }}"
+      loop: "{{ jellyfin_youtube_library_files }}"
       when:
         - not ansible_check_mode
         - jellyfin_service_cycle_needed | bool

--- a/ansible/templates/jellyfin/YouTube/YouTube.mblink.j2
+++ b/ansible/templates/jellyfin/YouTube/YouTube.mblink.j2
@@ -1,1 +1,0 @@
-{{ pinchflat_shows_dir }}


### PR DESCRIPTION
## Summary
- Jellyfin stored the YouTube library path as `/mnt/nas/Multimedia/YouTube/shows\n` because the mblink had a trailing newline, so scans failed
- Add `tvshows.collection` (same pattern as Shows) so the library is typed as TV shows
- Deploy the mblink via `copy: content` with no trailing newline

## Test plan
- [ ] On next, `xxd /var/lib/jellyfin/root/default/YouTube/YouTube.mblink` ends with `shows` and no `0a`
- [ ] `tvshows.collection` exists beside it
- [ ] After Jellyfin restart + library scan, Pinchflat shows appear under the YouTube library


Made with [Cursor](https://cursor.com)